### PR TITLE
addresses the problem of multiple OL map instances

### DIFF
--- a/alpine_ace/src/Components/test_3.jsx
+++ b/alpine_ace/src/Components/test_3.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import Map from "ol/Map";
 import View from "ol/View";
 import TileLayer from "ol/layer/Tile";
@@ -12,100 +12,132 @@ import Collection from "ol/Collection";
 import { TileWMS } from "ol/source";
 import { Projection } from "ol/proj";
 
+// this could be moved to a separate JS module
+function createMap() {
+  // TODO: refactor hard-coded values as function parameters
+
+  // Base map
+  const extent = [2420000, 130000, 2900000, 1350000];
+
+  const swisstopoLayer = new TileLayer({
+    extent: extent,
+    source: new TileWMS({
+      url: "https://wms.geo.admin.ch/",
+      crossOrigin: "anonymous",
+      attributions:
+        '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
+        'en/home.html">geo.admin.ch</a>',
+      projection: "EPSG:2056",
+      params: {
+        LAYERS: "ch.swisstopo.pixelkarte-farbe-winter",
+        FORMAT: "image/jpeg",
+      },
+      serverType: "mapserver",
+    }),
+  });
+
+  const map = new Map({
+    layers: [swisstopoLayer],
+    view: new View({
+      center: [2762073, 1180429],
+      zoom: 12,
+      projection: new Projection({
+        code: "EPSG:2056",
+        units: "m",
+      }),
+    }),
+  });
+
+  return map;
+}
+
+function createMarkersLayer(map) {
+  if (!map) {
+    throw new Error("Map is required");
+  }
+
+  const vectorSource = new VectorSource({
+    features: [],
+  });
+
+  const vectorLayer = new VectorLayer({
+    source: vectorSource,
+  });
+
+  map.addLayer(vectorLayer);
+
+  return vectorLayer;
+}
+
+function addMarker(map, layer, coords, style) {
+  const markerStyle = new Style(
+    style || {
+      image: new Icon({
+        src: "//raw.githubusercontent.com/jonataswalker/map-utils/master/images/marker.png",
+        scale: 0.7,
+        anchor: [0.5, 1],
+      }),
+    }
+  );
+
+  const markerGeometry = new Point(coords);
+  const markerFeature = new Feature(markerGeometry);
+  markerFeature.setStyle(markerStyle);
+
+  // add feature to the layer
+  layer.getSource().addFeature(markerFeature);
+
+  // event handling
+  const translate = new Translate({
+    features: new Collection([markerFeature]), // Use a collection to pass markerFeature1
+  });
+  map.addInteraction(translate);
+
+  translate.on("translatestart", evt => {
+    // Handle translatestart event
+    console.log("Translatifon started:", evt);
+  });
+
+  translate.on("translateend", evt => {
+    // Handle translateend event
+    console.log("Translation ended:", evt);
+  });
+}
+
+// creating the map and markers layer outside the component!!!
+const map = createMap();
+const markersLayer = createMarkersLayer(map);
+
 const MapWithMarkers = () => {
-  const [showMarker, setShowMarker] = useState(false);
-  const [map, setMap] = useState(null);
+  const [markersLayerHidden, setMarkersLayerHidden] = useState(false);
+  const mapContainerRef = useRef();
 
   const handleButtonClick = () => {
-    setShowMarker(true);
+    setMarkersLayerHidden(!markersLayerHidden);
   };
 
   useEffect(() => {
-    if (!map) {
-      const extent = [2420000, 130000, 2900000, 1350000];
-      const swisstopoLayer = new TileLayer({
-        extent: extent,
-        source: new TileWMS({
-          url: "https://wms.geo.admin.ch/",
-          crossOrigin: "anonymous",
-          attributions:
-            '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
-            'en/home.html">geo.admin.ch</a>',
-          projection: "EPSG:2056",
-          params: {
-            LAYERS: "ch.swisstopo.pixelkarte-farbe-winter",
-            FORMAT: "image/jpeg",
-          },
-          serverType: "mapserver",
-        }),
-      });
-      const newMap = new Map({
-        target: "map",
-        layers: [swisstopoLayer],
-        view: new View({
-          center: [2762073, 1180429],
-          zoom: 12,
-          projection: new Projection({
-            code: "EPSG:2056",
-            units: "m",
-          }),
-        }),
-      });
-      setMap(newMap);
-    }
-  }, [map]);
+    markersLayer.setVisible(!markersLayerHidden);
+  }, [markersLayerHidden]);
 
   useEffect(() => {
-    if (showMarker && map) {
-      const coord1 = [2762073, 1180429];
+    // add a test marker
+    addMarker(map, markersLayer, [2762073, 1180429]);
 
-      const markerStyle = new Style({
-        image: new Icon({
-          src: "//raw.githubusercontent.com/jonataswalker/map-utils/master/images/marker.png",
-          scale: 0.7,
-          anchor: [0.5, 1],
-        }),
-      });
-
-      const marker1 = new Point(coord1);
-      const markerFeature1 = new Feature(marker1);
-      markerFeature1.setStyle(markerStyle);
-
-      const vectorSource = new VectorSource({
-        features: [markerFeature1],
-      });
-
-      const vectorLayer = new VectorLayer({
-        source: vectorSource,
-      });
-
-      map.addLayer(vectorLayer);
-
-      const translate1 = new Translate({
-        features: new Collection([markerFeature1]), // Use a collection to pass markerFeature1
-      });
-      map.addInteraction(translate1);
-
-      translate1.on("translatestart", (evt) => {
-        // Handle translatestart event
-        console.log("Translatifon started:", evt);
-      });
-
-      translate1.on("translateend", (evt) => {
-        // Handle translateend event
-        console.log("Translation ended:", evt);
-      });
-
-      return () => {
-        map.removeLayer(vectorLayer);
-      };
-    }
-  }, [showMarker]); // Only run once when showMarker changes
+    // set the DOM node target for the map
+    map.setTarget(mapContainerRef.current);
+  }, []);
 
   return (
     <div>
-      <button onClick={handleButtonClick}>Show Marker</button>
-      <div id="map" style={{ width: "100%", height: "400px" }}></div>
+      <button onClick={handleButtonClick}>
+        {markersLayerHidden ? "Show Marker" : "Hide Marker"}
+      </button>
+      <div
+        ref={mapContainerRef}
+        // id="map"
+        style={{ width: "100%", height: "400px" }}
+      ></div>
     </div>
   );
 };

--- a/alpine_ace/src/index.js
+++ b/alpine_ace/src/index.js
@@ -1,14 +1,14 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "./index.css";
+import App from "./App";
+import reportWebVitals from "./reportWebVitals";
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  // <React.StrictMode>
+  <App />
+  // </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
# Genereles Problem

[OpenLayers](https://openlayers.org/) ist eine (imperative) DOM-Manipulation Library. Verwendung in React Apps ist möglich, aber nicht trivial.

Zu empfehlen wäre eine Verwendung von React Libraries. Mir sind nur diese 2 Optionen bekannt:

1. [react-openlayer](https://github.com/allenhwkim/react-openlayers):  seit langem keine Updates!!!
2. [react-leaflet](https://react-leaflet.js.org/): Ist Leaflet und kein OL!!!

Ich habe dennoch versucht, die Funktionalität - so wie ich sie verstanden habe - so umzusetzen, dass dies funktioniert (siehe Änderungen in `alpine_ace/src/Components/test_3.jsx` und `alpine_ace/src/index.js`).

## Wann wird die Karte 2-fach (oder mehrfach!!!) in DOM eingefügt?

**1.**
Wenn `<React.StrictMode>` verwendet wird, wird die Karte 2 mal in DOM eingefügt. Das ist wieder das Problem zwischen deklarativen React und der imperativen OL library und ließe sich mit entsprechenden DOM-Manimpulation lösen (überprüfen ob eine eine Karten Instanz bereits existiert, und ggf. keine diese vorher entfernen). Deshalb habe ich den strict mode deaktiviert (nicht unbedingt optimal!):

```jsx
  // <React.StrictMode>
  <App />
  // </React.StrictMode>
```

**2.**
Wenn man mit einem lokalen Development Server mit "hot reloading" arbeitet, kann es unter Umständen passieren, dass 2 Karten Instanzen auch mit diesem Code dargestellt werden. In dem Fall muss einfach die Seite neu laden.

